### PR TITLE
QA: fix openWindow path for subfolder hosting

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -365,7 +365,8 @@ self.addEventListener('notificationclick', (event) => {
                     }
                 }
                 if (clients.openWindow) {
-                    return clients.openWindow('/');
+                    // Use service worker scope to support subfolder hosting
+                    return clients.openWindow(self.registration.scope);
                 }
             })
         );


### PR DESCRIPTION
## Summary
- adjust notification click handler to open the service worker scope instead of `/`

## Testing
- `node smoketest.js`
- `node check_sw.js`

------
https://chatgpt.com/codex/tasks/task_e_686108fbb620832e8ea1a30272e0e5e8