### PR TITLE
Switch service worker to ES module

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -114,7 +114,7 @@ class MarketSignalApp {
     async initServiceWorker() {
         try {
             if ('serviceWorker' in navigator) {
-                const registration = await navigator.serviceWorker.register('./sw.js');
+                const registration = await navigator.serviceWorker.register('./sw.js', { type: 'module' });
                 
                 // Handle service worker updates
                 registration.addEventListener('updatefound', () => {

--- a/js/config.js
+++ b/js/config.js
@@ -1,0 +1,1 @@
+export const APPS_SCRIPT_URL = 'https://script.google.com/macros/s/AKfycbxjC5rcbSwKzeXgFG2LU4hgkrVYGcufvyP301v7wat6t_55y2wxyudn6qmiT3j1O48/exec';

--- a/sw.js
+++ b/sw.js
@@ -3,6 +3,8 @@
  * Enhanced PWA functionality with offline support and caching
  */
 
+import { APPS_SCRIPT_URL } from './js/config.js';
+
 const CACHE_NAME = 'market-signal-dashboard-v3.2';
 const STATIC_CACHE = 'market-signal-static-v3.2';
 const DATA_CACHE = 'market-signal-data-v3.2';
@@ -25,7 +27,7 @@ const STATIC_FILES = [
 
 // API endpoints to cache – direct (no proxy). To re-enable proxy, add it here.
 const API_ENDPOINTS = [
-    'https://script.google.com/macros/s/AKfycbxjC5rcbSwKzeXgFG2LU4hgkrVYGcufvyP301v7wat6t_55y2wxyudn6qmiT3j1O48/exec'
+    APPS_SCRIPT_URL
 ];
 
 // Cache strategies


### PR DESCRIPTION
## Summary
- import config via ES module in `sw.js`
- register service worker as a module in `app.js`
- provide exported config constant

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6861262288d4832eb715160247fdbc26